### PR TITLE
fix: ssl-enforcement policy should support x509 attributes

### DIFF
--- a/src/main/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicy.java
+++ b/src/main/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicy.java
@@ -92,7 +92,10 @@ public class SslEnforcementPolicy {
             boolean found = false;
 
             for (String name : configuration.getWhitelistClientCertificates()) {
-                found = areEqual(new X500Name(name), peerName);
+                // Prepare name with javax.security to transform to valid bouncycastle Asn1ObjectIdentifier
+                final X500Principal x500Principal = new X500Principal(name);
+                final X500Name x500Name = new X500Name(x500Principal.getName());
+                found = areEqual(x500Name, peerName);
 
                 if (found) {
                     break;

--- a/src/test/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicyTest.java
@@ -167,4 +167,18 @@ public class SslEnforcementPolicyTest {
 
         verify(policyChain).doNext(request, response);
     }
+
+    @Test
+    public void shouldSuccess_withState() throws SSLPeerUnverifiedException {
+        when(configuration.isRequiresSsl()).thenReturn(true);
+        when(configuration.isRequiresClientAuthentication()).thenReturn(true);
+        when(configuration.getWhitelistClientCertificates())
+            .thenReturn(Collections.singletonList("C=FR, O=GraviteeSource, CN=localhost, OU=Eng, L=Lille 1, S=Lille"));
+        when(sslSession.getPeerPrincipal())
+            .thenReturn(new X500Principal("CN=localhost, O=GraviteeSource, C=FR, OU=Eng, L=Lille 1, S=Lille"));
+
+        policy.onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7276

**Description**

`S` attribute is not supported.
To do that, transform the names in whitelist to `X500Principal` to modify the attributes to be safely used by bouncycastle `X500Name`.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.1-SNAPSHOT.issues-7276-ssl-x509`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ssl-enforcement/1.2.1-SNAPSHOT.issues-7276-ssl-x509/gravitee-policy-ssl-enforcement-1.2.1-SNAPSHOT.issues-7276-ssl-x509.zip)
  <!-- Version placeholder end -->
