### PR TITLE
Use regex to validate DN in schema form

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -19,7 +19,8 @@
       "title": "Allowed client certificates (requires client authentication)",
       "items" : {
         "type" : "string",
-        "description": "Name of client (X.500 principal). Can be expressed with an Ant pattern.",
+        "pattern": "^(?: *[A-Z]+ *= *(?:\\w|\\*|\\?| )+,?)*$",
+        "description": "Name of client (X.500 principal). Can be expressed with an Ant pattern. For example: CN=localhost,O=GraviteeSource*,C=??",
         "title": "Distinguish Name"
       }
     }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-862
https://github.com/gravitee-io/issues/issues/6457

**Description**

Use regex to validate DN in schema form
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.2-APIM-862-improve-schema-form-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ssl-enforcement/1.2.2-APIM-862-improve-schema-form-SNAPSHOT/gravitee-policy-ssl-enforcement-1.2.2-APIM-862-improve-schema-form-SNAPSHOT.zip)
  <!-- Version placeholder end -->
