### PR TITLE
Apim 2140 sslenforcement

### DIFF
--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,3 +6,4 @@ class=io.gravitee.policy.sslenforcement.SslEnforcementPolicy
 type=policy
 category=security
 icon=ssl-enforcement.svg
+proxy=REQUEST

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,22 +1,23 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:policy:sslenforcement:configuration:SslEnforcementPolicyConfiguration",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
   "properties" : {
     "requiresSsl" : {
       "title": "Requires SSL",
-      "description": "Requires SSL",
+      "description": "Requires SSL.",
       "type" : "boolean",
       "default": true
     },
     "requiresClientAuthentication" : {
       "title": "Requires client authentication",
-      "description": "Consumer must pass a valid certificate",
+      "description": "Consumer must pass a valid certificate.",
       "type" : "boolean",
       "default": false
     },
     "whitelistClientCertificates" : {
       "type" : "array",
-      "title": "Allowed client certificates (requires client authentication)",
+      "title": "Allowed client certificates (requires client authentication).",
       "items" : {
         "type" : "string",
         "pattern": "^( *[A-Z0-9.]+ *= *([^,]+)+,?)*$",


### PR DESCRIPTION
**Issue**

APIM-2140

**Description**

- update schema form & add exec phase
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.3.0-apim-2140-sslenforcement-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ssl-enforcement/1.3.0-apim-2140-sslenforcement-SNAPSHOT/gravitee-policy-ssl-enforcement-1.3.0-apim-2140-sslenforcement-SNAPSHOT.zip)
  <!-- Version placeholder end -->
