### PR TITLE
chore: update gravitee dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,17 +30,17 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.0</version>
+        <version>21.0.1</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>4.0.3</gravitee-bom.version>
-        <gravitee-gateway-api.version>2.0.1</gravitee-gateway-api.version>
+        <gravitee-bom.version>3.0.24</gravitee-bom.version>
+        <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>2.1.0</gravitee-common.version>
+        <gravitee-common.version>2.3.0</gravitee-common.version>
         <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
 
-        <gravitee-json-validation.version>1.0.0</gravitee-json-validation.version>
+        <gravitee-json-validation.version>1.0.1</gravitee-json-validation.version>
         <commons-io.version>1.3.2</commons-io.version>
 
         <maven-assembly-plugin.version>3.5.0</maven-assembly-plugin.version>


### PR DESCRIPTION
**Description**

Comply with the version defined in the latest 3.20


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.4.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ssl-enforcement/1.4.0/gravitee-policy-ssl-enforcement-1.4.0.zip)
  <!-- Version placeholder end -->
