### PR TITLE
fix: ssl enforcement policy issue

### DIFF
--- a/src/main/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicy.java
+++ b/src/main/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicy.java
@@ -77,6 +77,14 @@ public class SslEnforcementPolicy {
         }
 
         var principal = extractX500Principal(request);
+        if (!configuration.isRequiresClientAuthentication() && principal == null) {
+            policyChain.failWith(
+                PolicyResult.failure(SSL_REQUIRED, HttpStatusCode.FORBIDDEN_403, "Access to the resource requires SSL certificate.")
+            );
+
+            return;
+        }
+
         if (configuration.isRequiresClientAuthentication() && principal == null) {
             policyChain.failWith(PolicyResult.failure(AUTHENTICATION_REQUIRED, HttpStatusCode.UNAUTHORIZED_401, "Unauthorized"));
 

--- a/src/test/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicyTest.java
@@ -72,7 +72,7 @@ class SslEnforcementPolicyTest {
     @Test
     void should_go_to_next_policy_when_require_ssl_is_disabled() {
         var configuration = SslEnforcementPolicyConfiguration.builder().requiresSsl(false).build();
-
+        when(request.sslSession()).thenReturn(null);
         new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
 
         verify(policyChain).doNext(request, response);
@@ -173,6 +173,18 @@ class SslEnforcementPolicyTest {
 
         verify(policyChain).failWith(resultCaptor.capture());
         Assertions.assertThat(resultCaptor.getValue().key()).isEqualTo(SslEnforcementPolicy.AUTHENTICATION_REQUIRED);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_fail_when_require_client_authentication_is_disabled_and_http_mode() {
+        when(sslSession.getPeerPrincipal()).thenReturn(null);
+        var configuration = SslEnforcementPolicyConfiguration.builder().requiresSsl(true).requiresClientAuthentication(false).build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).failWith(resultCaptor.capture());
+        Assertions.assertThat(resultCaptor.getValue().key()).isEqualTo(SslEnforcementPolicy.SSL_REQUIRED);
     }
 
     @Test


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12084

**Description**

Changed the code to throw 403 error when principal is null and RequiresClientAuthentication is disabled

https://github.com/user-attachments/assets/3dfec2f7-5fd0-49cc-a9c2-e61a28b75da1


