### PR TITLE
feat: if SSL connection is terminated at the ingress getting 403

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -45,11 +45,29 @@ consumers for a given set of certificates.
 ^.^|boolean
 ^.^|true
 
+.^|useXForwardedProto
+^.^|-
+|When enabled, treat the request as HTTPS if X-Forwarded-Proto or Forwarded header indicates https (e.g. TLS terminated at ingress). Enable this option only if the gateway is behind a trusted proxy.
+^.^|boolean
+^.^|false
+
 .^|requiresClientAuthentication
 ^.^|-
 |Is client authentication required to access this resource?
 ^.^|boolean
 ^.^|false
+
+.^|certificateLocation
+^.^|-
+|Where to read the client certificate: `SESSION` (from SSL session) or `HEADER` (from HTTP header, e.g. when behind a reverse proxy that forwards the cert).
+^.^|enum [`SESSION`, `HEADER`]
+^.^|SESSION
+
+.^|certificateHeaderName
+^.^|-
+|Name of the header containing the client certificate. Used when `certificateLocation` is `HEADER`.
+^.^|string
+^.^|ssl-client-cert
 
 .^|whitelistClientCertificates
 ^.^|-
@@ -58,6 +76,20 @@ consumers for a given set of certificates.
 ^.^|-
 
 |===
+
+=== Behind a reverse proxy (Nginx)
+
+When the gateway is behind Nginx (or a similar reverse proxy) that terminates TLS, configure Nginx to forward the session information:
+
+[source,nginx]
+----
+proxy_set_header   X-Forwarded-Proto $scheme;
+proxy_set_header   X-SSL-CERT $ssl_client_escaped_cert;
+proxy_set_header   X-Cert-Verified $ssl_client_verify;
+proxy_set_header   X-Cert-Dn $ssl_client_s_dn;
+----
+
+Then configure your policy with `useXForwardedProto`, `certificateLocation`, and `certificateHeaderName` (e.g. `certificateLocation=HEADER` and `certificateHeaderName=X-SSL-CERT`).
 
 === Configuration example
 

--- a/src/main/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicy.java
+++ b/src/main/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicy.java
@@ -59,16 +59,16 @@ public class SslEnforcementPolicy {
 
     @OnRequest
     public void onRequest(Request request, Response response, PolicyChain policyChain) {
-        SSLSession sslSession = request.sslSession();
+        boolean secure = isSecure(request);
 
         // No SSL at all, go to next policy
-        if (!configuration.isRequiresSsl() && sslSession == null) {
+        if (!configuration.isRequiresSsl() && !secure) {
             policyChain.doNext(request, response);
 
             return;
         }
 
-        if (configuration.isRequiresSsl() && sslSession == null) {
+        if (configuration.isRequiresSsl() && !secure) {
             policyChain.failWith(
                 PolicyResult.failure(SSL_REQUIRED, HttpStatusCode.FORBIDDEN_403, "Access to the resource requires SSL certificate.")
             );
@@ -118,6 +118,31 @@ public class SslEnforcementPolicy {
         }
 
         policyChain.doNext(request, response);
+    }
+
+    private boolean isSecure(Request request) {
+        if (request.sslSession() != null) {
+            return true;
+        }
+        if (configuration.isUseXForwardedProto()) {
+            return forwardedProtoIsHttps(request.headers());
+        }
+        return false;
+    }
+
+    private boolean forwardedProtoIsHttps(HttpHeaders headers) {
+        if (headers == null) {
+            return false;
+        }
+        String xForwardedProto = headers.get("X-Forwarded-Proto");
+        if (xForwardedProto != null && "https".equalsIgnoreCase(xForwardedProto.trim())) {
+            return true;
+        }
+        String forwarded = headers.get("Forwarded");
+        if (forwarded != null && forwarded.toLowerCase().contains("proto=https")) {
+            return true;
+        }
+        return false;
     }
 
     private X500Principal extractX500Principal(Request request) {

--- a/src/main/java/io/gravitee/policy/sslenforcement/configuration/SslEnforcementPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/sslenforcement/configuration/SslEnforcementPolicyConfiguration.java
@@ -35,6 +35,13 @@ public class SslEnforcementPolicyConfiguration implements PolicyConfiguration {
     @Builder.Default
     private boolean requiresSsl = true;
 
+    /**
+     * When true, treat the request as HTTPS if X-Forwarded-Proto or Forwarded header indicates
+     * https (e.g. TLS terminated at ingress). Only enable when the gateway is behind a trusted proxy.
+     */
+    @Builder.Default
+    private boolean useXForwardedProto = false;
+
     private boolean requiresClientAuthentication;
 
     /** Allowed client certificates (requires client authentication) **/

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -9,6 +9,12 @@
       "type" : "boolean",
       "default": true
     },
+    "useXForwardedProto" : {
+      "title": "Use X-Forwarded-Proto",
+      "description": "When enabled, treat the request as HTTPS if X-Forwarded-Proto or Forwarded header indicates https (e.g. TLS terminated at ingress). Only enable when behind a trusted proxy.",
+      "type" : "boolean",
+      "default": false
+    },
     "requiresClientAuthentication" : {
       "title": "Requires client authentication",
       "description": "Consumer must pass a valid certificate.",

--- a/src/test/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicyTest.java
@@ -164,6 +164,59 @@ class SslEnforcementPolicyTest {
     }
 
     @Test
+    void should_go_to_next_policy_when_requires_ssl_and_trust_x_forwarded_proto_and_header_https() {
+        when(request.sslSession()).thenReturn(null);
+        HttpHeaders headers = HttpHeaders.create().set("X-Forwarded-Proto", "https");
+        when(request.headers()).thenReturn(headers);
+
+        var configuration = SslEnforcementPolicyConfiguration.builder().requiresSsl(true).useXForwardedProto(true).build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
+
+    @Test
+    void should_fail_when_requires_ssl_and_trust_x_forwarded_proto_but_proto_is_http() {
+        when(request.sslSession()).thenReturn(null);
+        HttpHeaders headers = HttpHeaders.create().set("X-Forwarded-Proto", "http");
+        when(request.headers()).thenReturn(headers);
+
+        var configuration = SslEnforcementPolicyConfiguration.builder().requiresSsl(true).useXForwardedProto(true).build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).failWith(resultCaptor.capture());
+        Assertions.assertThat(resultCaptor.getValue().key()).isEqualTo(SslEnforcementPolicy.SSL_REQUIRED);
+    }
+
+    @Test
+    void should_fail_when_requires_ssl_and_x_forwarded_proto_https_but_trust_disabled() {
+        when(request.sslSession()).thenReturn(null);
+        // When useXForwardedProto is false, policy does not read headers; no need to stub headers.
+
+        var configuration = SslEnforcementPolicyConfiguration.builder().requiresSsl(true).useXForwardedProto(false).build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).failWith(resultCaptor.capture());
+        Assertions.assertThat(resultCaptor.getValue().key()).isEqualTo(SslEnforcementPolicy.SSL_REQUIRED);
+    }
+
+    @Test
+    void should_go_to_next_policy_when_trust_x_forwarded_proto_and_forwarded_header_proto_https() {
+        when(request.sslSession()).thenReturn(null);
+        HttpHeaders headers = HttpHeaders.create().set("Forwarded", "proto=https");
+        when(request.headers()).thenReturn(headers);
+
+        var configuration = SslEnforcementPolicyConfiguration.builder().requiresSsl(true).useXForwardedProto(true).build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
+
+    @Test
     @SneakyThrows
     void should_fail_when_require_client_authentication_is_enabled_but_no_certifcate() {
         when(sslSession.getPeerPrincipal()).thenReturn(null);

--- a/src/test/java/io/gravitee/policy/sslenforcement/configuration/SslEnforcementPolicyConfigurationTest.java
+++ b/src/test/java/io/gravitee/policy/sslenforcement/configuration/SslEnforcementPolicyConfigurationTest.java
@@ -43,6 +43,7 @@ class SslEnforcementPolicyConfigurationTest {
 
         JSONObject defaultConfig = new JSONObject();
         defaultConfig.put("requiresSsl", true);
+        defaultConfig.put("useXForwardedProto", false);
         defaultConfig.put("requiresClientAuthentication", false);
         defaultConfig.put("certificateLocation", "SESSION");
         defaultConfig.put("certificateHeaderName", "ssl-client-cert");


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13081

Problem
When TLS is terminated at the ingress/CDN (e.g. Client → CDN → Nginx Ingress → Gateway), the gateway receives plain HTTP and has no SSL session. The SSL Enforcement policy treats the request as insecure and returns 403 Forbidden with "Access to the resource requires SSL certificate.".

Solution
Introduce a trustXForwardedProto configuration option so the policy considers a request secure when the proxy sends X-Forwarded-Proto: https or Forwarded: proto=https.

Aspect | Details
-- | --
Issue | 403 Forbidden when SSL is terminated at ingress (gateway receives HTTP, sslSession == null)
Root cause | Policy only treated requests as secure when sslSession != null; no support for proxied scheme headers
Change | Add trustXForwardedProto configuration option
Behavior | When trustXForwardedProto=true, treat the request as secure if X-Forwarded-Proto: https or Forwarded: proto=https is present
Default | trustXForwardedProto=false (no change in default behavior)


https://github.com/user-attachments/assets/0bf76a79-6ea3-470c-a662-0e6138500bcb

