### PR TITLE
Apim 13263 extract x509 certificate

### DIFF
--- a/src/main/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicy.java
+++ b/src/main/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicy.java
@@ -28,6 +28,7 @@ import io.gravitee.policy.sslenforcement.configuration.SslEnforcementPolicyConfi
 import java.io.ByteArrayInputStream;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Optional;
@@ -76,8 +77,8 @@ public class SslEnforcementPolicy {
             return;
         }
 
-        var principal = extractX500Principal(request);
-        if (configuration.isRequiresClientAuthentication() && principal == null) {
+        var certificate = extractCertificate(request).orElse(null);
+        if (configuration.isRequiresClientAuthentication() && certificate == null) {
             policyChain.failWith(PolicyResult.failure(AUTHENTICATION_REQUIRED, HttpStatusCode.UNAUTHORIZED_401, "Unauthorized"));
 
             return;
@@ -88,6 +89,7 @@ public class SslEnforcementPolicy {
             configuration.getWhitelistClientCertificates() != null &&
             !configuration.getWhitelistClientCertificates().isEmpty()
         ) {
+            X500Principal principal = certificate.getSubjectX500Principal();
             X500Name peerName = new X500Name(principal.getName());
 
             boolean found = false;
@@ -145,23 +147,24 @@ public class SslEnforcementPolicy {
         return false;
     }
 
-    private X500Principal extractX500Principal(Request request) {
+    private Optional<X509Certificate> extractCertificate(Request request) {
         if (configuration.getCertificateLocation() == CertificateLocation.SESSION) {
             SSLSession sslSession = request.sslSession();
-
-            if (null != sslSession) {
-                try {
-                    return (X500Principal) sslSession.getPeerPrincipal();
-                } catch (SSLPeerUnverifiedException e) {
-                    return null;
-                }
+            if (sslSession == null) {
+                return Optional.empty();
             }
-            return null;
+            try {
+                Certificate[] peerCertificates = sslSession.getPeerCertificates();
+                if (peerCertificates != null && peerCertificates.length > 0 && peerCertificates[0] instanceof X509Certificate x509) {
+                    return Optional.of(x509);
+                }
+                return Optional.empty();
+            } catch (SSLPeerUnverifiedException e) {
+                return Optional.empty();
+            }
         }
 
-        return extractCertificate(request.headers(), configuration.getCertificateHeaderName())
-            .map(X509Certificate::getSubjectX500Principal)
-            .orElse(null);
+        return extractCertificate(request.headers(), configuration.getCertificateHeaderName());
     }
 
     public static Optional<X509Certificate> extractCertificate(final HttpHeaders httpHeaders, final String certHeader) {

--- a/src/test/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicyTest.java
@@ -26,10 +26,14 @@ import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.PolicyResult;
 import io.gravitee.policy.sslenforcement.configuration.CertificateLocation;
 import io.gravitee.policy.sslenforcement.configuration.SslEnforcementPolicyConfiguration;
+import java.io.InputStream;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.util.Collections;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
@@ -241,9 +245,33 @@ class SslEnforcementPolicyTest {
         Assertions.assertThat(resultCaptor.getValue().key()).isEqualTo(SslEnforcementPolicy.CLIENT_FORBIDDEN);
     }
 
+    @Test
+    @SneakyThrows
+    void should_go_to_next_policy_when_session_peer_certificate_subject_matches_whitelist() {
+        X509Certificate cert = loadX509Certificate();
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistClientCertificates(Collections.singletonList("CN=Duke,OU=JavaSoft,O=Sun Microsystems,C=US"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
+
     @SneakyThrows
     private String loadCertificate() {
         var cert = Files.readString(Path.of(requireNonNull(this.getClass().getResource("/cert.pem")).toURI()));
         return URLEncoder.encode(cert, Charset.defaultCharset());
+    }
+
+    @SneakyThrows
+    private X509Certificate loadX509Certificate() {
+        try (InputStream is = requireNonNull(this.getClass().getResourceAsStream("/cert.pem"))) {
+            return (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(is);
+        }
     }
 }

--- a/src/test/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicyTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.policy.sslenforcement;
 
 import static java.util.Objects.requireNonNull;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -92,7 +93,7 @@ class SslEnforcementPolicyTest {
     )
     void should_go_to_next_policy_when_consumer_certificate_in_session_is_in_the_whitelist(String whitelist)
         throws SSLPeerUnverifiedException {
-        when(sslSession.getPeerPrincipal()).thenReturn(new X500Principal("CN=Duke,OU=JavaSoft,O=Sun Microsystems,C=US"));
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { loadX509Certificate() });
         var configuration = SslEnforcementPolicyConfiguration.builder()
             .requiresSsl(true)
             .requiresClientAuthentication(true)
@@ -115,7 +116,7 @@ class SslEnforcementPolicyTest {
     )
     void should_go_to_next_policy_when_consumer_certificate_in_session_match_to_pattern_in_the_whitelist(String pattern)
         throws SSLPeerUnverifiedException {
-        when(sslSession.getPeerPrincipal()).thenReturn(new X500Principal("CN=Duke,OU=JavaSoft,O=Sun Microsystems,C=US"));
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { loadX509Certificate() });
         var configuration = SslEnforcementPolicyConfiguration.builder()
             .requiresSsl(true)
             .requiresClientAuthentication(true)
@@ -220,7 +221,7 @@ class SslEnforcementPolicyTest {
     @Test
     @SneakyThrows
     void should_fail_when_require_client_authentication_is_enabled_but_no_certifcate() {
-        when(sslSession.getPeerPrincipal()).thenReturn(null);
+        when(sslSession.getPeerCertificates()).thenThrow(new SSLPeerUnverifiedException("peer not verified"));
         var configuration = SslEnforcementPolicyConfiguration.builder().requiresSsl(true).requiresClientAuthentication(true).build();
 
         new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
@@ -232,7 +233,9 @@ class SslEnforcementPolicyTest {
     @Test
     @SneakyThrows
     void should_fail_when_the_consumer_certificate_does_not_match_with_the_whitelist() {
-        when(sslSession.getPeerPrincipal()).thenReturn(new X500Principal("CN=Unknown"));
+        X509Certificate cert = mock(X509Certificate.class);
+        when(cert.getSubjectX500Principal()).thenReturn(new X500Principal("CN=Unknown"));
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
         var configuration = SslEnforcementPolicyConfiguration.builder()
             .requiresSsl(true)
             .requiresClientAuthentication(true)


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13263

**Description**

Unifies client certificate extraction in the SSL Enforcement policy. Both `SESSION` and `HEADER` paths now return the full `X509Certificate` via a single `extractCertificate(request)` method, and the `X500Principal` is derived at the DN match site via `cert.getSubjectX500Principal()`.

Prerequisite for APIM-13264 (certificatePolicies OID enforcement) and APIM-13265 (SAN whitelist enforcement), which both need access to the full certificate to read X.509 extensions and SAN entries.

Pure refactor — zero behavior change. DN whitelist matching works identically for both `SESSION` and `HEADER` modes.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.6.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ssl-enforcement/1.6.0/gravitee-policy-ssl-enforcement-1.6.0.zip)
  <!-- Version placeholder end -->
