### PR TITLE
feat: reject cert missing certificatePolicies extension when OIDs required

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -75,6 +75,12 @@ consumers for a given set of certificates.
 ^.^|array of strings
 ^.^|-
 
+.^|requiredCertificatePolicies
+^.^|-
+|List of OIDs (dotted-decimal) that must be present in the client certificate's `certificatePolicies` X.509 extension. Typical use: enforcing PSD2 / eIDAS QWAC compliance (e.g. `0.4.0.19495.1.3`). All listed OIDs must be present; empty / unset means no OID validation.
+^.^|array of strings
+^.^|-
+
 |===
 
 === Behind a reverse proxy (Nginx)
@@ -146,5 +152,8 @@ The error keys sent by this policy are as follows:
 
 .^|SSL_ENFORCEMENT_CLIENT_FORBIDDEN
 ^.^|name (X.500 name from client certificate)
+
+.^|SSL_ENFORCEMENT_OID_MISMATCH
+^.^|required (list of OIDs that must be present in `certificatePolicies`)
 
 |===

--- a/src/main/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicy.java
+++ b/src/main/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicy.java
@@ -31,12 +31,18 @@ import java.nio.charset.Charset;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.security.auth.x500.X500Principal;
 import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.asn1.ASN1OctetString;
+import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.CertificatePolicies;
+import org.bouncycastle.asn1.x509.PolicyInformation;
 import org.springframework.util.StringUtils;
 
 /**
@@ -53,6 +59,10 @@ public class SslEnforcementPolicy {
     static final String AUTHENTICATION_REQUIRED = "SSL_ENFORCEMENT_AUTHENTICATION_REQUIRED";
 
     static final String CLIENT_FORBIDDEN = "SSL_ENFORCEMENT_CLIENT_FORBIDDEN";
+
+    static final String OID_MISMATCH = "SSL_ENFORCEMENT_OID_MISMATCH";
+
+    private static final String CERTIFICATE_POLICIES_OID = "2.5.29.32";
 
     public SslEnforcementPolicy(SslEnforcementPolicyConfiguration configuration) {
         this.configuration = configuration;
@@ -119,6 +129,26 @@ public class SslEnforcementPolicy {
             }
         }
 
+        if (
+            configuration.isRequiresClientAuthentication() &&
+            configuration.getRequiredCertificatePolicies() != null &&
+            !configuration.getRequiredCertificatePolicies().isEmpty()
+        ) {
+            Set<String> presentOids = extractCertificatePolicyOids(certificate);
+            if (!presentOids.containsAll(configuration.getRequiredCertificatePolicies())) {
+                policyChain.failWith(
+                    PolicyResult.failure(
+                        OID_MISMATCH,
+                        HttpStatusCode.FORBIDDEN_403,
+                        "Certificate does not contain required policy OIDs",
+                        Maps.<String, Object>builder().put("required", configuration.getRequiredCertificatePolicies()).build()
+                    )
+                );
+
+                return;
+            }
+        }
+
         policyChain.doNext(request, response);
     }
 
@@ -165,6 +195,25 @@ public class SslEnforcementPolicy {
         }
 
         return extractCertificate(request.headers(), configuration.getCertificateHeaderName());
+    }
+
+    private static Set<String> extractCertificatePolicyOids(X509Certificate certificate) {
+        byte[] extensionValue = certificate.getExtensionValue(CERTIFICATE_POLICIES_OID);
+        if (extensionValue == null) {
+            return Set.of();
+        }
+        try {
+            ASN1OctetString octetString = (ASN1OctetString) ASN1Primitive.fromByteArray(extensionValue);
+            CertificatePolicies policies = CertificatePolicies.getInstance(ASN1Primitive.fromByteArray(octetString.getOctets()));
+            Set<String> oids = new HashSet<>();
+            for (PolicyInformation pi : policies.getPolicyInformation()) {
+                oids.add(pi.getPolicyIdentifier().getId());
+            }
+            return oids;
+        } catch (Exception e) {
+            log.debug("Unable to parse certificatePolicies extension", e);
+            return Set.of();
+        }
     }
 
     public static Optional<X509Certificate> extractCertificate(final HttpHeaders httpHeaders, final String certHeader) {

--- a/src/main/java/io/gravitee/policy/sslenforcement/configuration/SslEnforcementPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/sslenforcement/configuration/SslEnforcementPolicyConfiguration.java
@@ -47,6 +47,9 @@ public class SslEnforcementPolicyConfiguration implements PolicyConfiguration {
     /** Allowed client certificates (requires client authentication) **/
     private List<String> whitelistClientCertificates;
 
+    /** Required OIDs in the certificate's certificatePolicies extension (requires client authentication) **/
+    private List<String> requiredCertificatePolicies;
+
     @Builder.Default
     private CertificateLocation certificateLocation = CertificateLocation.SESSION;
 

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -43,6 +43,16 @@
                 "description": "Name of client (X.500 principal). Can be expressed with an Ant pattern. For example: CN=localhost,O=GraviteeSource*,C=??",
                 "title": "Distinguished Name"
             }
+        },
+        "requiredCertificatePolicies": {
+            "type": "array",
+            "title": "Required certificatePolicies OIDs (requires client authentication).",
+            "items": {
+                "type": "string",
+                "pattern": "^\\d+(\\.\\d+)+$",
+                "description": "Dotted-decimal OID that must appear in the client certificate's certificatePolicies extension. For example: 0.4.0.19495.1.3 (PSD2/eIDAS QWAC).",
+                "title": "Required policy OID"
+            }
         }
     }
 }

--- a/src/test/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicyTest.java
@@ -28,19 +28,33 @@ import io.gravitee.policy.api.PolicyResult;
 import io.gravitee.policy.sslenforcement.configuration.CertificateLocation;
 import io.gravitee.policy.sslenforcement.configuration.SslEnforcementPolicyConfiguration;
 import java.io.InputStream;
+import java.math.BigInteger;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.security.auth.x500.X500Principal;
 import lombok.SneakyThrows;
 import org.assertj.core.api.Assertions;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.CertificatePolicies;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.PolicyInformation;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -263,6 +277,161 @@ class SslEnforcementPolicyTest {
         new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
 
         verify(policyChain).doNext(request, response);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_fail_when_certificate_lacks_required_policy_oid() {
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { loadX509Certificate() });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .requiredCertificatePolicies(Collections.singletonList("0.4.0.19495.1.3"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).failWith(resultCaptor.capture());
+        Assertions.assertThat(resultCaptor.getValue().key()).isEqualTo(SslEnforcementPolicy.OID_MISMATCH);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_fail_when_certificate_policy_oids_do_not_include_required_oid() {
+        X509Certificate cert = buildCertWithPolicyOids("1.2.3.4");
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .requiredCertificatePolicies(Collections.singletonList("0.4.0.19495.1.3"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).failWith(resultCaptor.capture());
+        Assertions.assertThat(resultCaptor.getValue().key()).isEqualTo(SslEnforcementPolicy.OID_MISMATCH);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_go_to_next_policy_when_certificate_contains_required_policy_oid() {
+        X509Certificate cert = buildCertWithPolicyOids("0.4.0.19495.1.3");
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .requiredCertificatePolicies(Collections.singletonList("0.4.0.19495.1.3"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_fail_when_certificate_contains_only_some_of_multiple_required_policy_oids() {
+        X509Certificate cert = buildCertWithPolicyOids("0.4.0.19495.1.3");
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .requiredCertificatePolicies(java.util.List.of("0.4.0.19495.1.3", "1.2.3.4"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).failWith(resultCaptor.capture());
+        Assertions.assertThat(resultCaptor.getValue().key()).isEqualTo(SslEnforcementPolicy.OID_MISMATCH);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_fail_with_oid_mismatch_when_certificate_policies_extension_is_malformed() {
+        X509Certificate cert = mock(X509Certificate.class);
+        when(cert.getExtensionValue("2.5.29.32")).thenReturn(new byte[] { 0x42, 0x42, 0x42 });
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .requiredCertificatePolicies(Collections.singletonList("0.4.0.19495.1.3"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).failWith(resultCaptor.capture());
+        Assertions.assertThat(resultCaptor.getValue().key()).isEqualTo(SslEnforcementPolicy.OID_MISMATCH);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_go_to_next_policy_when_required_certificate_policies_is_not_configured() {
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { loadX509Certificate() });
+        var configuration = SslEnforcementPolicyConfiguration.builder().requiresSsl(true).requiresClientAuthentication(true).build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_go_to_next_policy_when_required_certificate_policies_is_empty() {
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { loadX509Certificate() });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .requiredCertificatePolicies(Collections.emptyList())
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_go_to_next_policy_when_certificate_contains_all_multiple_required_policy_oids() {
+        X509Certificate cert = buildCertWithPolicyOids("0.4.0.19495.1.3", "1.2.3.4");
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .requiredCertificatePolicies(java.util.List.of("0.4.0.19495.1.3", "1.2.3.4"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
+
+    @SneakyThrows
+    private static X509Certificate buildCertWithPolicyOids(String... oids) {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair keyPair = kpg.generateKeyPair();
+
+        X500Name issuer = new X500Name("CN=Test");
+        BigInteger serial = BigInteger.ONE;
+        Date notBefore = new Date();
+        Date notAfter = new Date(notBefore.getTime() + 365L * 24 * 60 * 60 * 1000);
+
+        PolicyInformation[] policies = Arrays.stream(oids)
+            .map(oid -> new PolicyInformation(new ASN1ObjectIdentifier(oid)))
+            .toArray(PolicyInformation[]::new);
+
+        JcaX509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+            issuer,
+            serial,
+            notBefore,
+            notAfter,
+            issuer,
+            keyPair.getPublic()
+        );
+        builder.addExtension(Extension.certificatePolicies, false, new CertificatePolicies(policies));
+
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSA").build(keyPair.getPrivate());
+        return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
     }
 
     @SneakyThrows


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13264

**Description**

Adds OID enforcement to the SSL Enforcement policy. When the new r`equiredCertificatePolicies` config field is set, the policy parses the client certificate's certificatePolicies X.509 extension and rejects requests whose cert doesn't contain all of the required OIDs. Rejection: 403 + new error key `SSL_ENFORCEMENT_OID_MISMATCH`.

Changes

  - `SslEnforcementPolicyConfiguration` — new field `requiredCertificatePolicies: List<String>`.
  - `SslEnforcementPolicy` — new constant `OID_MISMATCH`, new private helper `extractCertificatePolicyOids` (BouncyCastle ASN.1 parse of the extension), new check block in `onRequest` that fails when not all required OIDs are present in the cert.
  - `schema-form.json` — new array field with OID regex ^\d+(\.\d+)+$.
  - README.adoc — documents the new property and error key.

  Behavior

  - No `requiredCertificatePolicies` set / empty list → unchanged behavior (backward-compat).
  - Cert with no `certificatePolicies` extension → 403 + `SSL_ENFORCEMENT_OID_MISMATCH`.
  - Cert with extension but missing one or more required OIDs → 403 + `SSL_ENFORCEMENT_OID_MISMATCH`.
  - Cert with all required OIDs present → passes to next policy.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.0-APIM-13264-validate-certificate-policies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ssl-enforcement/1.7.0-APIM-13264-validate-certificate-policies-SNAPSHOT/gravitee-policy-ssl-enforcement-1.7.0-APIM-13264-validate-certificate-policies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
