### PR TITLE
APIM 13265 validate san whitelist

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -81,6 +81,12 @@ consumers for a given set of certificates.
 ^.^|array of strings
 ^.^|-
 
+.^|whitelistSubjectAlternativeNames
+^.^|-
+|List of allowed Subject Alternative Name values from the client certificate. Supports Ant-pattern matching (e.g. `*.example.com`, `partner-*`). At least one SAN value must match at least one pattern; empty / unset means no SAN validation. Matches across all SAN types (DNS, email, URI, IP).
+^.^|array of strings
+^.^|-
+
 |===
 
 === Behind a reverse proxy (Nginx)
@@ -155,5 +161,8 @@ The error keys sent by this policy are as follows:
 
 .^|SSL_ENFORCEMENT_OID_MISMATCH
 ^.^|required (list of OIDs that must be present in `certificatePolicies`)
+
+.^|SSL_ENFORCEMENT_SAN_MISMATCH
+^.^|whitelist (list of allowed SAN patterns)
 
 |===

--- a/src/main/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicy.java
+++ b/src/main/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicy.java
@@ -31,7 +31,9 @@ import java.nio.charset.Charset;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -43,6 +45,8 @@ import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.CertificatePolicies;
 import org.bouncycastle.asn1.x509.PolicyInformation;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -62,7 +66,17 @@ public class SslEnforcementPolicy {
 
     static final String OID_MISMATCH = "SSL_ENFORCEMENT_OID_MISMATCH";
 
+    static final String SAN_MISMATCH = "SSL_ENFORCEMENT_SAN_MISMATCH";
+
     private static final String CERTIFICATE_POLICIES_OID = "2.5.29.32";
+
+    // DNS and email SAN values are case-insensitive per RFC 5280 / 6125.
+    private static final AntPathMatcher SAN_MATCHER;
+
+    static {
+        SAN_MATCHER = new AntPathMatcher();
+        SAN_MATCHER.setCaseSensitive(false);
+    }
 
     public SslEnforcementPolicy(SslEnforcementPolicyConfiguration configuration) {
         this.configuration = configuration;
@@ -75,7 +89,6 @@ public class SslEnforcementPolicy {
         // No SSL at all, go to next policy
         if (!configuration.isRequiresSsl() && !secure) {
             policyChain.doNext(request, response);
-
             return;
         }
 
@@ -83,73 +96,90 @@ public class SslEnforcementPolicy {
             policyChain.failWith(
                 PolicyResult.failure(SSL_REQUIRED, HttpStatusCode.FORBIDDEN_403, "Access to the resource requires SSL certificate.")
             );
-
             return;
         }
 
         var certificate = extractCertificate(request).orElse(null);
         if (configuration.isRequiresClientAuthentication() && certificate == null) {
             policyChain.failWith(PolicyResult.failure(AUTHENTICATION_REQUIRED, HttpStatusCode.UNAUTHORIZED_401, "Unauthorized"));
-
             return;
         }
 
-        if (
-            configuration.isRequiresClientAuthentication() &&
-            configuration.getWhitelistClientCertificates() != null &&
-            !configuration.getWhitelistClientCertificates().isEmpty()
-        ) {
-            X500Principal principal = certificate.getSubjectX500Principal();
-            X500Name peerName = new X500Name(principal.getName());
-
-            boolean found = false;
-
-            for (String name : configuration.getWhitelistClientCertificates()) {
-                // Prepare name with javax.security to transform to valid bouncycastle Asn1ObjectIdentifier
-                final X500Principal x500Principal = new X500Principal(name);
-                final X500Name x500Name = new X500Name(x500Principal.getName());
-                found = X500NameComparator.areEqual(x500Name, peerName);
-
-                if (found) {
-                    break;
-                }
-            }
-
-            if (!found) {
-                policyChain.failWith(
-                    PolicyResult.failure(
-                        CLIENT_FORBIDDEN,
-                        HttpStatusCode.FORBIDDEN_403,
-                        "You're not allowed to access this resource",
-                        Maps.<String, Object>builder().put("name", principal.getName()).build()
-                    )
-                );
-
-                return;
-            }
-        }
-
-        if (
-            configuration.isRequiresClientAuthentication() &&
-            configuration.getRequiredCertificatePolicies() != null &&
-            !configuration.getRequiredCertificatePolicies().isEmpty()
-        ) {
-            Set<String> presentOids = extractCertificatePolicyOids(certificate);
-            if (!presentOids.containsAll(configuration.getRequiredCertificatePolicies())) {
-                policyChain.failWith(
-                    PolicyResult.failure(
-                        OID_MISMATCH,
-                        HttpStatusCode.FORBIDDEN_403,
-                        "Certificate does not contain required policy OIDs",
-                        Maps.<String, Object>builder().put("required", configuration.getRequiredCertificatePolicies()).build()
-                    )
-                );
-
-                return;
-            }
-        }
+        if (!enforceDnWhitelist(certificate, policyChain)) return;
+        if (!enforceRequiredOids(certificate, policyChain)) return;
+        if (!enforceSanWhitelist(certificate, policyChain)) return;
 
         policyChain.doNext(request, response);
+    }
+
+    private boolean enforceDnWhitelist(X509Certificate certificate, PolicyChain policyChain) {
+        if (!shouldEnforce(configuration.getWhitelistClientCertificates())) {
+            return true;
+        }
+        X500Principal principal = certificate.getSubjectX500Principal();
+        X500Name peerName = new X500Name(principal.getName());
+
+        for (String name : configuration.getWhitelistClientCertificates()) {
+            // Prepare name with javax.security to transform to valid bouncycastle Asn1ObjectIdentifier
+            final X500Name x500Name = new X500Name(new X500Principal(name).getName());
+            if (X500NameComparator.areEqual(x500Name, peerName)) {
+                return true;
+            }
+        }
+
+        policyChain.failWith(
+            PolicyResult.failure(
+                CLIENT_FORBIDDEN,
+                HttpStatusCode.FORBIDDEN_403,
+                "You're not allowed to access this resource",
+                Maps.<String, Object>builder().put("name", principal.getName()).build()
+            )
+        );
+        return false;
+    }
+
+    private boolean enforceRequiredOids(X509Certificate certificate, PolicyChain policyChain) {
+        if (!shouldEnforce(configuration.getRequiredCertificatePolicies())) {
+            return true;
+        }
+        Set<String> presentOids = extractCertificatePolicyOids(certificate);
+        if (presentOids.containsAll(configuration.getRequiredCertificatePolicies())) {
+            return true;
+        }
+        policyChain.failWith(
+            PolicyResult.failure(
+                OID_MISMATCH,
+                HttpStatusCode.FORBIDDEN_403,
+                "Certificate does not contain required policy OIDs",
+                Maps.<String, Object>builder().put("required", configuration.getRequiredCertificatePolicies()).build()
+            )
+        );
+        return false;
+    }
+
+    private boolean enforceSanWhitelist(X509Certificate certificate, PolicyChain policyChain) {
+        if (!shouldEnforce(configuration.getWhitelistSubjectAlternativeNames())) {
+            return true;
+        }
+        Collection<List<?>> sans;
+        try {
+            sans = certificate.getSubjectAlternativeNames();
+        } catch (Exception e) {
+            log.debug("Unable to read subject alternative names from certificate", e);
+            sans = null;
+        }
+        if (sans != null && !sans.isEmpty() && anySanMatchesWhitelist(sans, configuration.getWhitelistSubjectAlternativeNames())) {
+            return true;
+        }
+        policyChain.failWith(
+            PolicyResult.failure(
+                SAN_MISMATCH,
+                HttpStatusCode.FORBIDDEN_403,
+                "Certificate does not match required Subject Alternative Names",
+                Maps.<String, Object>builder().put("whitelist", configuration.getWhitelistSubjectAlternativeNames()).build()
+            )
+        );
+        return false;
     }
 
     private boolean isSecure(Request request) {
@@ -195,6 +225,27 @@ public class SslEnforcementPolicy {
         }
 
         return extractCertificate(request.headers(), configuration.getCertificateHeaderName());
+    }
+
+    private boolean shouldEnforce(Collection<?> whitelist) {
+        return configuration.isRequiresClientAuthentication() && !CollectionUtils.isEmpty(whitelist);
+    }
+
+    private static boolean anySanMatchesWhitelist(Collection<List<?>> sans, List<String> whitelist) {
+        for (List<?> san : sans) {
+            if (san.size() < 2) {
+                continue;
+            }
+            Object value = san.get(1);
+            if (value instanceof String sanValue) {
+                for (String pattern : whitelist) {
+                    if (SAN_MATCHER.match(pattern, sanValue)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     private static Set<String> extractCertificatePolicyOids(X509Certificate certificate) {

--- a/src/main/java/io/gravitee/policy/sslenforcement/configuration/SslEnforcementPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/sslenforcement/configuration/SslEnforcementPolicyConfiguration.java
@@ -50,6 +50,9 @@ public class SslEnforcementPolicyConfiguration implements PolicyConfiguration {
     /** Required OIDs in the certificate's certificatePolicies extension (requires client authentication) **/
     private List<String> requiredCertificatePolicies;
 
+    /** Allowed Subject Alternative Name values (requires client authentication). Supports Ant-pattern matching. **/
+    private List<String> whitelistSubjectAlternativeNames;
+
     @Builder.Default
     private CertificateLocation certificateLocation = CertificateLocation.SESSION;
 

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -53,6 +53,15 @@
                 "description": "Dotted-decimal OID that must appear in the client certificate's certificatePolicies extension. For example: 0.4.0.19495.1.3 (PSD2/eIDAS QWAC).",
                 "title": "Required policy OID"
             }
+        },
+        "whitelistSubjectAlternativeNames": {
+            "type": "array",
+            "title": "Allowed Subject Alternative Names (requires client authentication).",
+            "items": {
+                "type": "string",
+                "description": "SAN value from the client certificate. Supports Ant-pattern matching (e.g. *.example.com, partner-*). Matches across all SAN types (DNS, email, URI, IP).",
+                "title": "SAN pattern"
+            }
         }
     }
 }

--- a/src/test/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicyTest.java
@@ -39,8 +39,10 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.security.auth.x500.X500Principal;
@@ -50,6 +52,8 @@ import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.CertificatePolicies;
 import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.asn1.x509.PolicyInformation;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
@@ -365,6 +369,169 @@ class SslEnforcementPolicyTest {
 
     @Test
     @SneakyThrows
+    void should_go_to_next_policy_when_certificate_san_matches_whitelist_ant_pattern() {
+        X509Certificate cert = buildCertWithSan("api.example.com");
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistSubjectAlternativeNames(Collections.singletonList("*.example.com"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_go_to_next_policy_when_any_one_of_multiple_san_values_matches_whitelist() {
+        X509Certificate cert = buildCertWithSan("api.other.com", "api.allowed.com", "api.third.com");
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistSubjectAlternativeNames(Collections.singletonList("api.allowed.com"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_go_to_next_policy_when_san_matches_whitelist_case_insensitively() {
+        // Per RFC 5280 / 6125, DNS and email SAN values are case-insensitive.
+        // A cert with SAN "API.Example.com" must match whitelist "api.example.com".
+        X509Certificate cert = buildCertWithSan("API.Example.com");
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistSubjectAlternativeNames(Collections.singletonList("api.example.com"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_go_to_next_policy_when_certificate_san_matches_whitelist_literal() {
+        X509Certificate cert = buildCertWithSan("api.allowed.com");
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistSubjectAlternativeNames(Collections.singletonList("api.allowed.com"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_fail_when_certificate_san_values_do_not_match_whitelist() {
+        X509Certificate cert = buildCertWithSan("api.other.com");
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistSubjectAlternativeNames(Collections.singletonList("api.allowed.com"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).failWith(resultCaptor.capture());
+        Assertions.assertThat(resultCaptor.getValue().key()).isEqualTo(SslEnforcementPolicy.SAN_MISMATCH);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_go_to_next_policy_when_whitelist_subject_alternative_names_is_not_configured() {
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { loadX509Certificate() });
+        var configuration = SslEnforcementPolicyConfiguration.builder().requiresSsl(true).requiresClientAuthentication(true).build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_go_to_next_policy_when_whitelist_subject_alternative_names_is_empty() {
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { loadX509Certificate() });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistSubjectAlternativeNames(Collections.emptyList())
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_go_to_next_policy_when_non_dns_san_type_matches_whitelist() {
+        // GeneralName type 1 = rfc822Name (email). Verifies the policy matches against
+        // SAN values regardless of the type integer (ticket AC: "All SAN types matched").
+        X509Certificate cert = mock(X509Certificate.class);
+        Collection<List<?>> sans = List.of(Arrays.asList(1, "partner@allowed.com"));
+        when(cert.getSubjectAlternativeNames()).thenReturn(sans);
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistSubjectAlternativeNames(Collections.singletonList("partner@allowed.com"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_fail_with_san_mismatch_when_get_subject_alternative_names_throws() {
+        X509Certificate cert = mock(X509Certificate.class);
+        when(cert.getSubjectAlternativeNames()).thenThrow(new RuntimeException("malformed extension"));
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistSubjectAlternativeNames(Collections.singletonList("api.example.com"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).failWith(resultCaptor.capture());
+        Assertions.assertThat(resultCaptor.getValue().key()).isEqualTo(SslEnforcementPolicy.SAN_MISMATCH);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_fail_when_certificate_has_no_subject_alternative_names() {
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { loadX509Certificate() });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistSubjectAlternativeNames(Collections.singletonList("api.example.com"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).failWith(resultCaptor.capture());
+        Assertions.assertThat(resultCaptor.getValue().key()).isEqualTo(SslEnforcementPolicy.SAN_MISMATCH);
+    }
+
+    @Test
+    @SneakyThrows
     void should_go_to_next_policy_when_required_certificate_policies_is_not_configured() {
         when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { loadX509Certificate() });
         var configuration = SslEnforcementPolicyConfiguration.builder().requiresSsl(true).requiresClientAuthentication(true).build();
@@ -445,5 +612,35 @@ class SslEnforcementPolicyTest {
         try (InputStream is = requireNonNull(this.getClass().getResourceAsStream("/cert.pem"))) {
             return (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(is);
         }
+    }
+
+    @SneakyThrows
+    private static X509Certificate buildCertWithSan(String... dnsNames) {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair keyPair = kpg.generateKeyPair();
+
+        X500Name issuer = new X500Name("CN=Test");
+        BigInteger serial = BigInteger.ONE;
+        Date notBefore = new Date();
+        Date notAfter = new Date(notBefore.getTime() + 365L * 24 * 60 * 60 * 1000);
+
+        GeneralName[] names = Arrays.stream(dnsNames)
+            .map(n -> new GeneralName(GeneralName.dNSName, n))
+            .toArray(GeneralName[]::new);
+        GeneralNames sans = new GeneralNames(names);
+
+        JcaX509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+            issuer,
+            serial,
+            notBefore,
+            notAfter,
+            issuer,
+            keyPair.getPublic()
+        );
+        builder.addExtension(Extension.subjectAlternativeName, false, sans);
+
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSA").build(keyPair.getPrivate());
+        return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13265

**Description**

Adds Subject Alternative Name (SAN) whitelist enforcement to the SSL Enforcement policy. When `whitelistSubjectAlternativeNames` is configured, the policy reads the client certificate's SAN values via
  `X509Certificate.getSubjectAlternativeNames()` and rejects the request unless at least one SAN value matches at least one whitelist pattern. Rejection: 403 + new error key `SSL_ENFORCEMENT_SAN_MISMATCH`.

  Behavior
  - No / empty `whitelistSubjectAlternativeNames` → unchanged behavior (backward-compat).
  - Cert with no SAN extension when whitelist is configured → 403 + `SAN_MISMATCH`.
  - Cert SAN values, none match any whitelist pattern → 403 + `SAN_MISMATCH`.
  - Cert SAN exactly matches a whitelist literal → passes.
  - Cert SAN matches a whitelist Ant pattern (e.g. *.example.com) → passes.
  - Any-match semantics: at least one SAN value matches at least one pattern (mirrors the existing DN whitelist, not the OID "all-must-be-present" semantics).
  - All SAN types (DNS, email, URI, IP) are matched — no type filtering, per ticket AC.
  - Malformed extension or parse error → safely treated as no SAN entries (rejection).

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.0-APIM-13265-validate-san-whitelist-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ssl-enforcement/1.7.0-APIM-13265-validate-san-whitelist-SNAPSHOT/gravitee-policy-ssl-enforcement-1.7.0-APIM-13265-validate-san-whitelist-SNAPSHOT.zip)
  <!-- Version placeholder end -->
