### PR TITLE
feat: gate OID/SAN fields on client auth and add schema tests (APIM-13266)

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -52,6 +52,13 @@
                 "pattern": "^\\d+(\\.\\d+)+$",
                 "description": "Dotted-decimal OID that must appear in the client certificate's certificatePolicies extension. For example: 0.4.0.19495.1.3 (PSD2/eIDAS QWAC).",
                 "title": "Required policy OID"
+            },
+            "gioConfig": {
+                "displayIf": {
+                    "$eq": {
+                        "value.requiresClientAuthentication": true
+                    }
+                }
             }
         },
         "whitelistSubjectAlternativeNames": {
@@ -61,6 +68,13 @@
                 "type": "string",
                 "description": "SAN value from the client certificate. Supports Ant-pattern matching (e.g. *.example.com, partner-*). Matches across all SAN types (DNS, email, URI, IP).",
                 "title": "SAN pattern"
+            },
+            "gioConfig": {
+                "displayIf": {
+                    "$eq": {
+                        "value.requiresClientAuthentication": true
+                    }
+                }
             }
         }
     }

--- a/src/test/java/io/gravitee/policy/sslenforcement/configuration/SslEnforcementPolicyConfigurationTest.java
+++ b/src/test/java/io/gravitee/policy/sslenforcement/configuration/SslEnforcementPolicyConfigurationTest.java
@@ -88,6 +88,75 @@ class SslEnforcementPolicyConfigurationTest {
         Assertions.assertThrows(InvalidJsonException.class, () -> jsonSchemaValidator.validate(schema, config));
     }
 
+    @Test
+    @DisplayName("Should validate dotted-decimal OIDs in requiredCertificatePolicies")
+    void shouldValidateRequiredCertificatePolicies() {
+        JSONArray oids = new JSONArray();
+        oids.put("0.4.0.19495.1.3");
+        oids.put("1.3.6.1.4.1.311.21.1");
+        oids.put("2.5.29.32");
+        oids.put("1.2");
+
+        String config = new JSONObject().put("requiredCertificatePolicies", oids).toString();
+
+        String validated = jsonSchemaValidator.validate(schema, config);
+
+        assertThat(validated).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("Should accept an empty requiredCertificatePolicies list")
+    void shouldAcceptEmptyRequiredCertificatePolicies() {
+        String config = new JSONObject().put("requiredCertificatePolicies", new JSONArray()).toString();
+
+        String validated = jsonSchemaValidator.validate(schema, config);
+
+        assertThat(validated).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("Should throw with invalid OID format in requiredCertificatePolicies")
+    void shouldThrowWithInvalidOid() {
+        for (String invalidOid : new String[] { "not-an-oid", "1.2.3.", ".1.2", "1..2", "1.2.a", "" }) {
+            JSONArray oids = new JSONArray().put(invalidOid);
+            String config = new JSONObject().put("requiredCertificatePolicies", oids).toString();
+
+            Assertions.assertThrows(
+                InvalidJsonException.class,
+                () -> jsonSchemaValidator.validate(schema, config),
+                "Expected rejection for OID: '" + invalidOid + "'"
+            );
+        }
+    }
+
+    @Test
+    @DisplayName("Should accept SAN patterns in whitelistSubjectAlternativeNames")
+    void shouldValidateWhitelistSubjectAlternativeNames() {
+        JSONArray sans = new JSONArray();
+        sans.put("partner.example.com");
+        sans.put("*.example.com");
+        sans.put("partner-*");
+        sans.put("admin@example.com");
+        sans.put("https://example.com/service");
+        sans.put("10.0.0.1");
+
+        String config = new JSONObject().put("whitelistSubjectAlternativeNames", sans).toString();
+
+        String validated = jsonSchemaValidator.validate(schema, config);
+
+        assertThat(validated).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("Should accept an empty whitelistSubjectAlternativeNames list")
+    void shouldAcceptEmptyWhitelistSubjectAlternativeNames() {
+        String config = new JSONObject().put("whitelistSubjectAlternativeNames", new JSONArray()).toString();
+
+        String validated = jsonSchemaValidator.validate(schema, config);
+
+        assertThat(validated).isNotBlank();
+    }
+
     @SneakyThrows
     private String loadResource(String resource) {
         return Files.readString(Path.of(requireNonNull(this.getClass().getResource(resource)).toURI()));


### PR DESCRIPTION
## Summary

- Add `gioConfig.displayIf` to `requiredCertificatePolicies` and `whitelistSubjectAlternativeNames` so the APIM Console only shows them when `requiresClientAuthentication` is enabled.
- Add JSON schema validation tests for the new fields: valid OIDs, invalid OID formats (multiple cases), empty lists, valid SAN patterns.

The gateway-side enforcement was added in #63 (APIM-13264, OID) and #64 (APIM-13265, SAN); their `shouldEnforce` helper already treats null and empty lists as "no validation", so existing configurations without the new fields keep working.

Jira: https://gravitee.atlassian.net/browse/APIM-13266

## Test plan
- [x] `mvn test` — 45/45 passing locally
- [ ] Console renders the policy form with the OID/SAN fields hidden until "Requires client authentication" is toggled on
- [ ] OID field rejects malformed values (e.g. `abc`, `1.2.3.`) in the UI
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.0-APIM-13266-schema-conditional-visibility-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ssl-enforcement/1.7.0-APIM-13266-schema-conditional-visibility-SNAPSHOT/gravitee-policy-ssl-enforcement-1.7.0-APIM-13266-schema-conditional-visibility-SNAPSHOT.zip)
  <!-- Version placeholder end -->
