### PR TITLE
docs: document OID/SAN validation, PSD2 example, and upgrade notes (APIM-13267)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -114,6 +114,51 @@ Then configure your policy with `useXForwardedProto`, `certificateLocation`, and
     ]
 }
 
+==== Required `certificatePolicies` OIDs
+
+Reject requests unless the client certificate's `certificatePolicies` X.509 extension contains all the listed OIDs. All listed OIDs must be present; if the list is empty or unset, no OID validation is performed.
+
+[source, json]
+"ssl-enforcement" : {
+    "requiresSsl": true,
+    "requiresClientAuthentication": true,
+    "requiredCertificatePolicies": [
+        "0.4.0.19495.1.3"
+    ]
+}
+
+==== Subject Alternative Name whitelist
+
+Reject requests unless at least one Subject Alternative Name on the client certificate matches one of the listed patterns. Patterns use Ant-style matching (`*`, `?`, `**`) and are evaluated against all SAN types (DNS, email, URI, IP). An empty or unset list disables SAN validation.
+
+[source, json]
+"ssl-enforcement" : {
+    "requiresSsl": true,
+    "requiresClientAuthentication": true,
+    "whitelistSubjectAlternativeNames": [
+        "*.partner.example.com",
+        "billing-*"
+    ]
+}
+
+=== PSD2 / Open Banking (eIDAS QWAC)
+
+Under PSD2, payment service providers identify themselves with an eIDAS-issued QWAC certificate. The QWAC policy OID `0.4.0.19495.1.3` must be present in the certificate's `certificatePolicies` extension. The configuration below enforces TLS, client authentication, and the QWAC OID, and additionally restricts access to a whitelisted set of PSP organisation identifiers carried as SANs.
+
+[source, json]
+"ssl-enforcement" : {
+    "requiresSsl": true,
+    "requiresClientAuthentication": true,
+    "requiredCertificatePolicies": [
+        "0.4.0.19495.1.3"
+    ],
+    "whitelistSubjectAlternativeNames": [
+        "PSDXX-XXX-*"
+    ]
+}
+
+A request that does not present a QWAC with the required policy OID is rejected with `403` and the `SSL_ENFORCEMENT_OID_MISMATCH` error key. A request whose SAN values do not match the whitelist is rejected with `403` and `SSL_ENFORCEMENT_SAN_MISMATCH`.
+
 [[gravitee-policy-resource-filtering-ant]]
 === Ant style path pattern
 URL mapping matches URLs using the following rules:
@@ -145,24 +190,36 @@ option in the API *Proxy* menu).
 
 The error keys sent by this policy are as follows:
 
-[cols="2*", options="header"]
+[cols="3*", options="header"]
 |===
 ^|Key
+^|HTTP status
 ^|Parameters
 
 .^|SSL_ENFORCEMENT_SSL_REQUIRED
+^.^|403
 ^.^|-
 
 .^|SSL_ENFORCEMENT_AUTHENTICATION_REQUIRED
+^.^|401
 ^.^|-
 
 .^|SSL_ENFORCEMENT_CLIENT_FORBIDDEN
+^.^|403
 ^.^|name (X.500 name from client certificate)
 
 .^|SSL_ENFORCEMENT_OID_MISMATCH
+^.^|403
 ^.^|required (list of OIDs that must be present in `certificatePolicies`)
 
 .^|SSL_ENFORCEMENT_SAN_MISMATCH
+^.^|403
 ^.^|whitelist (list of allowed SAN patterns)
 
 |===
+
+== Upgrade notes
+
+`requiredCertificatePolicies` and `whitelistSubjectAlternativeNames` were introduced in plugin version `1.7.0`. Both are optional and additive: existing configurations that omit them keep their previous behaviour, and an empty list is equivalent to "no validation" for that check.
+
+Both checks are skipped entirely when `requiresClientAuthentication` is `false`, so they have no effect on APIs that do not require mTLS.


### PR DESCRIPTION
## Summary

Documentation pass for the X.509 extension validation work shipped in #63 (OID), #64 (SAN), and #65 (UI/schema). Closes APIM-13267.

- New configuration examples for `requiredCertificatePolicies` and `whitelistSubjectAlternativeNames` alongside the existing example.
- Dedicated **PSD2 / Open Banking (eIDAS QWAC)** section with concrete OID `0.4.0.19495.1.3`, fulfilling the epic's PSD2 use-case acceptance criterion.
- Added an **HTTP status** column to the error-keys table so consumers writing Response Templates can map keys to status codes at a glance.
- Added an **Upgrade notes** section: the new fields are additive, empty/unset = no validation, and checks are skipped when `requiresClientAuthentication` is `false`.

Jira: https://gravitee.atlassian.net/browse/APIM-13267

## Test plan
- [x] Diff inspected — heading levels and AsciiDoc table syntax consistent with the rest of the README.
- [ ] Render the README on GitHub and confirm the new tables and code blocks display correctly.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.0-APIM-13267-docs-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ssl-enforcement/1.7.0-APIM-13267-docs-SNAPSHOT/gravitee-policy-ssl-enforcement-1.7.0-APIM-13267-docs-SNAPSHOT.zip)
  <!-- Version placeholder end -->
