### PR TITLE
perf(ssl-enforcement): pre-parse DN whitelist to avoid per-request parsing

### DIFF
--- a/src/main/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicy.java
+++ b/src/main/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicy.java
@@ -31,6 +31,7 @@ import java.nio.charset.Charset;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -58,6 +59,13 @@ public class SslEnforcementPolicy {
 
     private final SslEnforcementPolicyConfiguration configuration;
 
+    /**
+     * DN whitelist pre-parsed into BouncyCastle {@link X500Name} objects at construction time.
+     * Policy instances are created once per API deployment, so parsing here keeps the per-request
+     * path allocation-free instead of re-parsing every configured DN on each call.
+     */
+    private final List<X500Name> whitelistClientCertificateNames;
+
     static final String SSL_REQUIRED = "SSL_ENFORCEMENT_SSL_REQUIRED";
 
     static final String AUTHENTICATION_REQUIRED = "SSL_ENFORCEMENT_AUTHENTICATION_REQUIRED";
@@ -80,6 +88,19 @@ public class SslEnforcementPolicy {
 
     public SslEnforcementPolicy(SslEnforcementPolicyConfiguration configuration) {
         this.configuration = configuration;
+        this.whitelistClientCertificateNames = parseWhitelistClientCertificates(configuration.getWhitelistClientCertificates());
+    }
+
+    private static List<X500Name> parseWhitelistClientCertificates(List<String> whitelist) {
+        if (CollectionUtils.isEmpty(whitelist)) {
+            return List.of();
+        }
+        List<X500Name> names = new ArrayList<>(whitelist.size());
+        for (String name : whitelist) {
+            // Normalize through javax.security so BouncyCastle gets canonical ASN.1 object identifiers.
+            names.add(new X500Name(new X500Principal(name).getName()));
+        }
+        return names;
     }
 
     @OnRequest
@@ -113,15 +134,13 @@ public class SslEnforcementPolicy {
     }
 
     private boolean enforceDnWhitelist(X509Certificate certificate, PolicyChain policyChain) {
-        if (!shouldEnforce(configuration.getWhitelistClientCertificates())) {
+        if (!configuration.isRequiresClientAuthentication() || whitelistClientCertificateNames.isEmpty()) {
             return true;
         }
         X500Principal principal = certificate.getSubjectX500Principal();
         X500Name peerName = new X500Name(principal.getName());
 
-        for (String name : configuration.getWhitelistClientCertificates()) {
-            // Prepare name with javax.security to transform to valid bouncycastle Asn1ObjectIdentifier
-            final X500Name x500Name = new X500Name(new X500Principal(name).getName());
+        for (X500Name x500Name : whitelistClientCertificateNames) {
             if (X500NameComparator.areEqual(x500Name, peerName)) {
                 return true;
             }

--- a/src/test/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicyTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.policy.sslenforcement;
 
 import static java.util.Objects.requireNonNull;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -89,7 +90,7 @@ class SslEnforcementPolicyTest {
 
     @BeforeEach
     void init() {
-        when(request.sslSession()).thenReturn(sslSession);
+        lenient().when(request.sslSession()).thenReturn(sslSession);
     }
 
     @Test
@@ -642,5 +643,18 @@ class SslEnforcementPolicyTest {
 
         ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSA").build(keyPair.getPrivate());
         return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
+    }
+
+    @Test
+    void should_fail_fast_at_construction_when_a_whitelist_dn_is_malformed() {
+        // DN whitelist is pre-parsed in the constructor, so a malformed entry surfaces at deploy
+        // time rather than throwing on every request.
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistClientCertificates(Collections.singletonList("this is not a valid distinguished name"))
+            .build();
+
+        Assertions.assertThatThrownBy(() -> new SslEnforcementPolicy(configuration)).isInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
## What

Pre-parse the client-certificate DN whitelist into BouncyCastle `X500Name` objects **once in the policy constructor** instead of re-parsing every configured DN on every request.

Addresses the performance feedback raised by Gemini on #67 (alpha → master), reviewed more broadly than the inline comments. Part of the APIM-13084 epic.

## Why

`enforceDnWhitelist` parsed `new X500Principal(name)` + `new X500Name(...)` for **every** whitelisted DN on **every** request. Policy instances are built once per API deployment, so this parsing belongs in the constructor. (Note: this loop predates alpha — it exists identically in master 1.6.0 — so the fix benefits the current policy too, not just the new OID/SAN features.)

The other alpha-era change reviewed (`getPeerPrincipal()` → `getPeerCertificates()[0]`) was measured to be free in practice (JSSE caches the peer chain post-handshake) and is required for OID/SAN, so it was left as-is.

## Measured impact

**JMH microbenchmark** (avg µs/op, worst-case match-at-end):

| whitelist size | before (master/alpha) | after | speedup |
|---:|---:|---:|---:|
| 10  | 48.1  | 12.1  | 4.0× |
| 50  | 224.8 | 41.1  | 5.5× |
| 200 | 864.2 | 149.2 | 5.8× |

Avoidable parse cost ≈ 3.6 µs per DN per request (linear in whitelist size before; flat after).

**End-to-end** (real mTLS gateway, k6, 16 VUs, 200-entry whitelist, local backend):

| | throughput | median latency | min latency |
|---|---:|---:|---:|
| master / alpha | ~3.5–4.4k RPS | ~3.5 ms | ~0.85 ms |
| this PR | ~7.3–8.2k RPS | ~1.4 ms | 0.33 ms |

≈ 2× throughput, ~55% lower median latency.

## Behavior change

A malformed DN in the whitelist now fails at **policy construction (deploy time)** rather than throwing on every request — strictly fail-fast. Covered by a new unit test.

## Tests

All 46 unit tests pass (`mvn test`), including the new `should_fail_fast_at_construction_when_a_whitelist_dn_is_malformed`.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.0-wba-ssl-enforcement-perf-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ssl-enforcement/1.7.0-wba-ssl-enforcement-perf-SNAPSHOT/gravitee-policy-ssl-enforcement-1.7.0-wba-ssl-enforcement-perf-SNAPSHOT.zip)
  <!-- Version placeholder end -->
