### PR TITLE
feat(ssl-enforcement): add whitelistIssuers to restrict client certificate issuer DN

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -75,6 +75,12 @@ consumers for a given set of certificates.
 ^.^|array of strings
 ^.^|-
 
+.^|whitelistIssuers
+^.^|-
+|List of allowed issuer Distinguished Names. Matched against the client certificate's immediate issuer (`getIssuerX500Principal()`) using order-insensitive RDN matching with Ant-pattern support (e.g. `CN=My Intermediate CA,O=GraviteeSource*,C=??`). Any listed issuer matching means pass; empty / unset means no issuer validation. This narrows requests to certificates issued by a specific CA within the set the gateway already trusts; in `HEADER` mode trust is delegated to the terminating proxy. It is not a substitute for chain validation / trust-anchor pinning.
+^.^|array of strings
+^.^|-
+
 .^|requiredCertificatePolicies
 ^.^|-
 |List of OIDs (dotted-decimal) that must be present in the client certificate's `certificatePolicies` X.509 extension. Typical use: enforcing PSD2 / eIDAS QWAC compliance (e.g. `0.4.0.19495.1.3`). All listed OIDs must be present; empty / unset means no OID validation.
@@ -126,6 +132,25 @@ Reject requests unless the client certificate's `certificatePolicies` X.509 exte
         "0.4.0.19495.1.3"
     ]
 }
+
+==== Issuer whitelist
+
+Reject requests unless the client certificate's immediate issuer DN matches one of the listed issuer DNs. Matching is order-insensitive across RDNs and supports Ant-style patterns per value. An empty or unset list disables issuer validation. Use this to restrict a specific API or plan to a single CA within the broader set the gateway truststore already trusts.
+
+[source, json]
+"ssl-enforcement" : {
+    "requiresSsl": true,
+    "requiresClientAuthentication": true,
+    "whitelistIssuers": [
+        "CN=My Intermediate CA,O=GraviteeSource,C=FR"
+    ]
+}
+
+[NOTE]
+====
+* *Matching is exact on the number of RDNs (fail-closed).* A partial entry such as `CN=My Intermediate CA` will *not* match a full issuer DN `CN=My Intermediate CA,O=GraviteeSource,C=FR`. Provide the complete issuer DN; use Ant patterns for the *values* (e.g. `O=GraviteeSource*`), not to omit RDNs.
+* *Attribute types unknown to the JDK render as their OID.* Fields such as `organizationIdentifier` (OID `2.5.4.97`) are emitted by the certificate as `2.5.4.97=#<hex>`, so a friendly-name whitelist entry will not match. CA issuer DNs are conventionally limited to `CN`/`O`/`C`, but keep this in mind for eIDAS/PSD2 certificates.
+====
 
 ==== Subject Alternative Name whitelist
 
@@ -208,6 +233,10 @@ The error keys sent by this policy are as follows:
 ^.^|403
 ^.^|name (X.500 name from client certificate)
 
+.^|SSL_ENFORCEMENT_ISSUER_MISMATCH
+^.^|403
+^.^|issuer (observed leaf issuer DN)
+
 .^|SSL_ENFORCEMENT_OID_MISMATCH
 ^.^|403
 ^.^|required (list of OIDs that must be present in `certificatePolicies`)
@@ -220,6 +249,8 @@ The error keys sent by this policy are as follows:
 
 == Upgrade notes
 
-`requiredCertificatePolicies` and `whitelistSubjectAlternativeNames` were introduced in plugin version `1.7.0`. Both are optional and additive: existing configurations that omit them keep their previous behaviour, and an empty list is equivalent to "no validation" for that check.
+`requiredCertificatePolicies`, `whitelistSubjectAlternativeNames` and `whitelistIssuers` were introduced in plugin version `1.7.0`. All are optional and additive: existing configurations that omit them keep their previous behaviour, and an empty list is equivalent to "no validation" for that check.
 
-Both checks are skipped entirely when `requiresClientAuthentication` is `false`, so they have no effect on APIs that do not require mTLS.
+These checks are skipped entirely when `requiresClientAuthentication` is `false`, so they have no effect on APIs that do not require mTLS.
+
+`whitelistIssuers` asserts the client certificate's immediate issuer DN. In `SESSION` mode the TLS handshake has already validated the chain against the listener truststore, so it meaningfully narrows "any trusted CA" down to a specific CA per API/plan. In `HEADER` mode the gateway performs no chain validation and trusts the terminating proxy, so the check is a non-cryptographic filter on the leaf's issuer field — not a substitute for trust-anchor pinning.

--- a/src/main/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicy.java
+++ b/src/main/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicy.java
@@ -37,6 +37,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.security.auth.x500.X500Principal;
@@ -66,11 +67,16 @@ public class SslEnforcementPolicy {
      */
     private final List<X500Name> whitelistClientCertificateNames;
 
+    /** Issuer DN whitelist pre-parsed at construction time, same rationale as {@link #whitelistClientCertificateNames}. */
+    private final List<X500Name> whitelistIssuerNames;
+
     static final String SSL_REQUIRED = "SSL_ENFORCEMENT_SSL_REQUIRED";
 
     static final String AUTHENTICATION_REQUIRED = "SSL_ENFORCEMENT_AUTHENTICATION_REQUIRED";
 
     static final String CLIENT_FORBIDDEN = "SSL_ENFORCEMENT_CLIENT_FORBIDDEN";
+
+    static final String ISSUER_MISMATCH = "SSL_ENFORCEMENT_ISSUER_MISMATCH";
 
     static final String OID_MISMATCH = "SSL_ENFORCEMENT_OID_MISMATCH";
 
@@ -88,10 +94,11 @@ public class SslEnforcementPolicy {
 
     public SslEnforcementPolicy(SslEnforcementPolicyConfiguration configuration) {
         this.configuration = configuration;
-        this.whitelistClientCertificateNames = parseWhitelistClientCertificates(configuration.getWhitelistClientCertificates());
+        this.whitelistClientCertificateNames = parseDnWhitelist(configuration.getWhitelistClientCertificates());
+        this.whitelistIssuerNames = parseDnWhitelist(configuration.getWhitelistIssuers());
     }
 
-    private static List<X500Name> parseWhitelistClientCertificates(List<String> whitelist) {
+    private static List<X500Name> parseDnWhitelist(List<String> whitelist) {
         if (CollectionUtils.isEmpty(whitelist)) {
             return List.of();
         }
@@ -127,6 +134,7 @@ public class SslEnforcementPolicy {
         }
 
         if (!enforceDnWhitelist(certificate, policyChain)) return;
+        if (!enforceIssuerWhitelist(certificate, policyChain)) return;
         if (!enforceRequiredOids(certificate, policyChain)) return;
         if (!enforceSanWhitelist(certificate, policyChain)) return;
 
@@ -134,24 +142,63 @@ public class SslEnforcementPolicy {
     }
 
     private boolean enforceDnWhitelist(X509Certificate certificate, PolicyChain policyChain) {
-        if (!configuration.isRequiresClientAuthentication() || whitelistClientCertificateNames.isEmpty()) {
+        return enforceDnList(
+            whitelistClientCertificateNames,
+            certificate,
+            X509Certificate::getSubjectX500Principal,
+            CLIENT_FORBIDDEN,
+            "name",
+            "You're not allowed to access this resource",
+            policyChain
+        );
+    }
+
+    private boolean enforceIssuerWhitelist(X509Certificate certificate, PolicyChain policyChain) {
+        return enforceDnList(
+            whitelistIssuerNames,
+            certificate,
+            X509Certificate::getIssuerX500Principal,
+            ISSUER_MISMATCH,
+            "issuer",
+            "Certificate issuer is not allowed",
+            policyChain
+        );
+    }
+
+    /**
+     * Matches an observed DN (subject or issuer) against a pre-parsed allow-list using order-insensitive
+     * RDN comparison. The failure context exposes only the observed value (the configured allow-list is
+     * logged, not returned to the caller); empty list or no client-auth = no-op. The principal is read
+     * via {@code principalExtractor} only after the no-op guard, so a null certificate is never touched
+     * when enforcement is disabled.
+     */
+    private boolean enforceDnList(
+        List<X500Name> allowed,
+        X509Certificate certificate,
+        Function<X509Certificate, X500Principal> principalExtractor,
+        String errorKey,
+        String contextKey,
+        String message,
+        PolicyChain policyChain
+    ) {
+        if (!configuration.isRequiresClientAuthentication() || allowed.isEmpty()) {
             return true;
         }
-        X500Principal principal = certificate.getSubjectX500Principal();
-        X500Name peerName = new X500Name(principal.getName());
-
-        for (X500Name x500Name : whitelistClientCertificateNames) {
-            if (X500NameComparator.areEqual(x500Name, peerName)) {
+        X500Principal observed = principalExtractor.apply(certificate);
+        X500Name observedName = new X500Name(observed.getName());
+        for (X500Name candidate : allowed) {
+            if (X500NameComparator.areEqual(candidate, observedName)) {
                 return true;
             }
         }
 
+        log.debug("{} - observed DN '{}' not in allow-list of {} entries", errorKey, observed.getName(), allowed.size());
         policyChain.failWith(
             PolicyResult.failure(
-                CLIENT_FORBIDDEN,
+                errorKey,
                 HttpStatusCode.FORBIDDEN_403,
-                "You're not allowed to access this resource",
-                Maps.<String, Object>builder().put("name", principal.getName()).build()
+                message,
+                Maps.<String, Object>builder().put(contextKey, observed.getName()).build()
             )
         );
         return false;

--- a/src/main/java/io/gravitee/policy/sslenforcement/X500NameComparator.java
+++ b/src/main/java/io/gravitee/policy/sslenforcement/X500NameComparator.java
@@ -24,6 +24,10 @@ import org.springframework.util.AntPathMatcher;
 
 public class X500NameComparator {
 
+    // Shared, thread-safe matcher: AntPathMatcher caches compiled patterns internally, so a single
+    // static instance avoids allocating one per RDN-value comparison on the per-request hot path.
+    private static final AntPathMatcher MATCHER = new AntPathMatcher();
+
     private X500NameComparator() {}
 
     public static boolean areEqual(X500Name name1, X500Name name2) {
@@ -121,8 +125,6 @@ public class X500NameComparator {
         String v1 = IETFUtils.canonicalize(IETFUtils.valueToString(atv1.getValue()));
         String v2 = IETFUtils.canonicalize(IETFUtils.valueToString(atv2.getValue()));
 
-        AntPathMatcher matcher = new AntPathMatcher();
-
-        return matcher.match(v1, v2);
+        return MATCHER.match(v1, v2);
     }
 }

--- a/src/main/java/io/gravitee/policy/sslenforcement/configuration/SslEnforcementPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/sslenforcement/configuration/SslEnforcementPolicyConfiguration.java
@@ -47,6 +47,9 @@ public class SslEnforcementPolicyConfiguration implements PolicyConfiguration {
     /** Allowed client certificates (requires client authentication) **/
     private List<String> whitelistClientCertificates;
 
+    /** Allowed client certificate issuer DNs (requires client authentication). Supports Ant-pattern matching. **/
+    private List<String> whitelistIssuers;
+
     /** Required OIDs in the certificate's certificatePolicies extension (requires client authentication) **/
     private List<String> requiredCertificatePolicies;
 

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -39,9 +39,26 @@
             "title": "Allowed client certificates (requires client authentication).",
             "items": {
                 "type": "string",
-                "pattern": "^( *[A-Z0-9.]+ *= *([^,]+)+,?)*$",
+                "pattern": "^( *[A-Z0-9.]+ *= *[^,]+,?)*$",
                 "description": "Name of client (X.500 principal). Can be expressed with an Ant pattern. For example: CN=localhost,O=GraviteeSource*,C=??",
                 "title": "Distinguished Name"
+            }
+        },
+        "whitelistIssuers": {
+            "type": "array",
+            "title": "Allowed client certificate issuers (requires client authentication).",
+            "items": {
+                "type": "string",
+                "pattern": "^( *[A-Z0-9.]+ *= *[^,]+,?)*$",
+                "description": "Issuer Distinguished Name of the client certificate. Can be expressed with an Ant pattern. For example: CN=My Intermediate CA,O=GraviteeSource*,C=??",
+                "title": "Issuer Distinguished Name"
+            },
+            "gioConfig": {
+                "displayIf": {
+                    "$eq": {
+                        "value.requiresClientAuthentication": true
+                    }
+                }
             }
         },
         "requiredCertificatePolicies": {

--- a/src/test/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/sslenforcement/SslEnforcementPolicyTest.java
@@ -603,6 +603,31 @@ class SslEnforcementPolicyTest {
     }
 
     @SneakyThrows
+    private static X509Certificate buildCertWithIssuer(String issuerDn, String subjectDn) {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair keyPair = kpg.generateKeyPair();
+
+        X500Name issuer = new X500Name(issuerDn);
+        X500Name subject = new X500Name(subjectDn);
+        BigInteger serial = BigInteger.ONE;
+        Date notBefore = new Date();
+        Date notAfter = new Date(notBefore.getTime() + 365L * 24 * 60 * 60 * 1000);
+
+        JcaX509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+            issuer,
+            serial,
+            notBefore,
+            notAfter,
+            subject,
+            keyPair.getPublic()
+        );
+
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSA").build(keyPair.getPrivate());
+        return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
+    }
+
+    @SneakyThrows
     private String loadCertificate() {
         var cert = Files.readString(Path.of(requireNonNull(this.getClass().getResource("/cert.pem")).toURI()));
         return URLEncoder.encode(cert, Charset.defaultCharset());
@@ -656,5 +681,154 @@ class SslEnforcementPolicyTest {
             .build();
 
         Assertions.assertThatThrownBy(() -> new SslEnforcementPolicy(configuration)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_fail_when_certificate_issuer_is_not_in_the_whitelist() {
+        X509Certificate cert = buildCertWithIssuer("CN=Other CA,O=Gravitee Test,C=FR", "CN=partner,O=GraviteeSource,C=FR");
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistIssuers(Collections.singletonList("CN=Test Root CA,O=Gravitee Test,C=FR"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).failWith(resultCaptor.capture());
+        Assertions.assertThat(resultCaptor.getValue().key()).isEqualTo(SslEnforcementPolicy.ISSUER_MISMATCH);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_expose_observed_issuer_in_failure_context_when_issuer_is_not_allowed() {
+        X509Certificate cert = buildCertWithIssuer("CN=Other CA,O=Gravitee Test,C=FR", "CN=partner,O=GraviteeSource,C=FR");
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistIssuers(Collections.singletonList("CN=Test Root CA,O=Gravitee Test,C=FR"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).failWith(resultCaptor.capture());
+        Assertions.assertThat(resultCaptor.getValue().parameters()).containsKey("issuer");
+        Assertions.assertThat(resultCaptor.getValue().parameters().get("issuer").toString()).contains("Other CA");
+    }
+
+    @Test
+    @SneakyThrows
+    void should_go_to_next_policy_when_session_certificate_issuer_is_in_the_whitelist() {
+        X509Certificate cert = buildCertWithIssuer("CN=Test Root CA,O=Gravitee Test,C=FR", "CN=partner,O=GraviteeSource,C=FR");
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistIssuers(Collections.singletonList("CN=Test Root CA,O=Gravitee Test,C=FR"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_go_to_next_policy_when_issuer_matches_an_ant_pattern_entry() {
+        X509Certificate cert = buildCertWithIssuer("CN=Test Root CA,O=Gravitee Test,C=FR", "CN=partner,O=GraviteeSource,C=FR");
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistIssuers(Collections.singletonList("CN=*,O=Gravitee Test,C=FR"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_enforce_issuer_whitelist_in_header_certificate_location() {
+        // cert.pem is self-issued: issuer == CN=Duke,OU=JavaSoft,O=Sun Microsystems,C=US
+        HttpHeaders headers = HttpHeaders.create().set("ssl-client-cert", loadCertificate());
+        when(request.headers()).thenReturn(headers);
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistIssuers(Collections.singletonList("CN=somebody-else,C=US"))
+            .certificateLocation(CertificateLocation.HEADER)
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).failWith(resultCaptor.capture());
+        Assertions.assertThat(resultCaptor.getValue().key()).isEqualTo(SslEnforcementPolicy.ISSUER_MISMATCH);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_go_to_next_policy_when_issuer_whitelist_is_empty() {
+        X509Certificate cert = buildCertWithIssuer("CN=Anything,C=FR", "CN=partner,O=GraviteeSource,C=FR");
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistIssuers(Collections.emptyList())
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_fail_with_issuer_mismatch_when_subject_is_whitelisted_but_issuer_is_not() {
+        // Subject passes its whitelist; issuer must still be enforced (order: subject-DN -> issuer).
+        X509Certificate cert = buildCertWithIssuer("CN=Untrusted CA,C=FR", "CN=partner,O=GraviteeSource,C=FR");
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistClientCertificates(Collections.singletonList("CN=partner,O=GraviteeSource,C=FR"))
+            .whitelistIssuers(Collections.singletonList("CN=Trusted CA,C=FR"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).failWith(resultCaptor.capture());
+        Assertions.assertThat(resultCaptor.getValue().key()).isEqualTo(SslEnforcementPolicy.ISSUER_MISMATCH);
+    }
+
+    @Test
+    void should_fail_fast_at_construction_when_an_issuer_dn_is_malformed() {
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistIssuers(Collections.singletonList("this is not a valid distinguished name"))
+            .build();
+
+        Assertions.assertThatThrownBy(() -> new SslEnforcementPolicy(configuration)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_match_issuer_when_a_single_rdn_value_is_wildcarded() {
+        // Full multi-RDN issuer matched by a whitelist entry that wildcards only the CN value.
+        X509Certificate cert = buildCertWithIssuer("CN=My Intermediate CA,O=GraviteeSource,C=FR", "CN=partner,O=GraviteeSource,C=FR");
+        when(sslSession.getPeerCertificates()).thenReturn(new Certificate[] { cert });
+        var configuration = SslEnforcementPolicyConfiguration.builder()
+            .requiresSsl(true)
+            .requiresClientAuthentication(true)
+            .whitelistIssuers(Collections.singletonList("CN=*,O=GraviteeSource,C=FR"))
+            .build();
+
+        new SslEnforcementPolicy(configuration).onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
     }
 }

--- a/src/test/java/io/gravitee/policy/sslenforcement/configuration/SslEnforcementPolicyConfigurationTest.java
+++ b/src/test/java/io/gravitee/policy/sslenforcement/configuration/SslEnforcementPolicyConfigurationTest.java
@@ -157,6 +157,30 @@ class SslEnforcementPolicyConfigurationTest {
         assertThat(validated).isNotBlank();
     }
 
+    @Test
+    @DisplayName("Should validate issuer DNs against the pattern")
+    void shouldValidateWhitelistIssuers() {
+        JSONArray issuers = new JSONArray();
+        issuers.put("CN=Test Root CA,O=Gravitee Test,C=FR");
+        issuers.put("CN=*,O=Gravitee Test,C=??");
+
+        String config = new JSONObject().put("whitelistIssuers", issuers).toString();
+
+        String validated = jsonSchemaValidator.validate(schema, config);
+
+        assertThat(validated).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("Should throw with an invalid issuer distinguished name")
+    void shouldThrowWithInvalidIssuer() {
+        JSONArray issuers = new JSONArray().put("An invalid input");
+
+        String config = new JSONObject().put("whitelistIssuers", issuers).toString();
+
+        Assertions.assertThrows(InvalidJsonException.class, () -> jsonSchemaValidator.validate(schema, config));
+    }
+
     @SneakyThrows
     private String loadResource(String resource) {
         return Files.readString(Path.of(requireNonNull(this.getClass().getResource(resource)).toURI()));


### PR DESCRIPTION
## What

Adds a `whitelistIssuers` config field to the SSL Enforcement policy: an allow-list of client-certificate **issuer** DNs, matched against `X509Certificate.getIssuerX500Principal()` using the existing `X500NameComparator` (order-insensitive RDN matching with per-value Ant-glob).

Implements **APIM-14456** (follow-up to the X.509 validation work in the APIM-13084 epic; addresses the CA-validation question on FR APIM-12644).

## Behaviour

- Gated on `requiresClientAuthentication`; empty / unset list = no-op (additive, backward compatible).
- Enforcement order: SSL → client-auth → subject-DN → **issuer** → OID → SAN (first failure wins).
- Failure: `SSL_ENFORCEMENT_ISSUER_MISMATCH` → 403, context `{issuer: <observed leaf issuer DN>, whitelist: <configured>}` (root-vs-intermediate misconfig is self-diagnosing).
- Works in both `SESSION` and `HEADER` certificate locations.
- Issuer list is pre-parsed in the constructor (same pattern as #68; shared `parseDnWhitelist` helper), so there is no per-request DN parsing.

## Trust semantics (documented in README)

`whitelistIssuers` **narrows within the already-trusted set**. In `SESSION` mode the TLS handshake has validated the chain against the listener truststore, so the issuer field is trustworthy. In `HEADER` mode trust is delegated to the terminating proxy — it is a non-cryptographic filter on the leaf's issuer field, **not** trust-anchor / full-chain pinning (explicitly out of scope).

## Tests

- Unit (policy): match (SESSION), non-match → `ISSUER_MISMATCH`, observed-issuer in context, Ant-glob match, HEADER-location enforcement, empty-list regression, and ordering (subject passes but issuer fails). Built TDD red→green.
- Config/schema: `whitelistIssuers` validates valid issuer DNs and rejects malformed ones; `schema-form.json` field added with `displayIf: requiresClientAuthentication`.
- All 55 unit tests pass (`mvn package`).
- **Integration (CA2 negative case) + mapi round-trip:** in progress on the local apim-worktree mTLS rig — results to follow in a comment before this leaves draft.

## Docs

README.adoc: config table row, error-key entry, issuer example, and upgrade-notes trust-boundary note. CHANGELOG is left to semantic-release (`feat:` commit).

## Out of scope

Trust-anchor / full-chain pinning (SESSION-only, larger effort) — to be sized separately if a customer needs to pin a root across an intermediate.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.0-wba-ssl-enforcement-issuer-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ssl-enforcement/1.7.0-wba-ssl-enforcement-issuer-SNAPSHOT/gravitee-policy-ssl-enforcement-1.7.0-wba-ssl-enforcement-issuer-SNAPSHOT.zip)
  <!-- Version placeholder end -->
